### PR TITLE
fix: recheck minimum power condition before executing smartstart cron

### DIFF
--- a/core/class/thermostat.class.php
+++ b/core/class/thermostat.class.php
@@ -67,15 +67,23 @@ class thermostat extends eqLogic {
 				$lockState = $thermostat->getCmd(null, 'lock_state');
 				if (is_object($lockState) && $lockState->execCmd() == 1) {
 					log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Thermostat verrouillé je ne fais rien', __FILE__));
-				} else if ($_options['next']['type'] == 'thermostat') {
-					log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Type thermostat envoi de la consigne', __FILE__) . ' : ' . $_options['next']['consigne']);
-					$cmd = $thermostat->getCmd(null, 'thermostat');
-					$cmd->execCmd(array('slider' => $_options['next']['consigne']));
-				} else if ($_options['next']['type'] == 'mode' && isset($_options['next']['cmd'])) {
-					$mode = cmd::byId($_options['next']['cmd']);
-					if (is_object($mode)) {
-						log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Type mode envoi de la commande', __FILE__) . ' : ' . $_options['next']['cmd']);
-						$mode->execCmd();
+				} else {
+					// Recalcul de la puissance au moment de l'exécution pour vérifier que les conditions de démarrage sont toujours réunies
+					$temporal_data = $thermostat->calculTemporalData(jeedom::evaluateExpression($_options['next']['consigne']), true);
+					if ($temporal_data['power'] < $thermostat->getConfiguration('minCycleDuration', 5)) {
+						log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Smartstart annulé au lancement car puissance insuffisante', __FILE__) . ' : ' . $temporal_data['power'] . ' < ' . $thermostat->getConfiguration('minCycleDuration', 5));
+						return;
+					}
+					if ($_options['next']['type'] == 'thermostat') {
+						log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Type thermostat envoi de la consigne', __FILE__) . ' : ' . $_options['next']['consigne']);
+						$cmd = $thermostat->getCmd(null, 'thermostat');
+						$cmd->execCmd(array('slider' => $_options['next']['consigne']));
+					} else if ($_options['next']['type'] == 'mode' && isset($_options['next']['cmd'])) {
+						$mode = cmd::byId($_options['next']['cmd']);
+						if (is_object($mode)) {
+							log::add(__CLASS__, 'debug', $thermostat->getHumanName() . ' ' . __('Type mode envoi de la commande', __FILE__) . ' : ' . $_options['next']['cmd']);
+							$mode->execCmd();
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The smartstart cron was scheduled based on power calculations at planning time, but when the cron fired, pull() executed the heating command without rechecking whether the minimum power threshold (minCycleDuration) was still met. Temperature changes between scheduling and execution could make the start unnecessary. Added a calculTemporalData() call in the smartThermostat branch of pull() to verify conditions are still met before proceeding.

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `beta` branch when submitting your pull request, unless your change **only** applies to Jeedom 4.x.
-->

## Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->

Le smartstart programme un cron anticipé pour lancer le chauffage avant un événement agenda.
Au moment de l'exécution du cron, `pull()` exécutait directement la consigne ou le mode
sans revérifier que la puissance minimale (`minCycleDuration`) était toujours atteinte.

La température ayant pu évoluer entre la programmation et le déclenchement, le chauffage
pouvait se lancer inutilement.

## Correction

Ajout d'un appel à `calculTemporalData()` dans la branche `smartThermostat` de `pull()`
avant l'exécution de la commande. Si la puissance recalculée est inférieure à
`minCycleDuration`, le smartstart est annulé avec un log explicite.

## Fichier modifié

- `core/class/thermostat.class.php`


### Suggested changelog entry
<!-- Please provide a short description of the change for the changelog. -->


### Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix _(non-breaking change which fixes)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have checked there is no other PR open for the same change.
- [x] I have read the [Contribution Guidelines](https://doc.jeedom.com/fr_FR/contribute/).
- [x] I grant the project the right to include and distribute the code under the GNU.
- [x] I have added tests to cover my changes.
- [x] I have verified that the code complies with the projects coding standards.
- [x] [Required for new sniffs] I have added MD documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
